### PR TITLE
Fix/calibration view issue

### DIFF
--- a/tools/ReFlex.TrackingServer/ClientApp/src/app/calibration/calibration.component.html
+++ b/tools/ReFlex.TrackingServer/ClientApp/src/app/calibration/calibration.component.html
@@ -201,7 +201,7 @@
             [(data)]="displayCalibratedInteractions"
             (onChange)="updateCalibrationToggle()"
             [disabled]="!this.update">
-            <span class="text" extraLabel>Calibrated Pos</span>          
+            <span class="text" extraLabel>Calibrated</span>          
         </app-panel-header>
 
         <div class="calibration__body">

--- a/tools/ReFlex.TrackingServer/ClientApp/src/app/calibration/calibration.component.html
+++ b/tools/ReFlex.TrackingServer/ClientApp/src/app/calibration/calibration.component.html
@@ -32,7 +32,7 @@
     </div>
 
     <div class="calibration__panel"
-        [ngStyle]="{'transform': 'translate('+borderOffset[3]+'px, '+borderOffset[0]+'px)'}">
+        [ngStyle]="{'transform': 'translate('+borderOffset[1]+'px, '+borderOffset[0]+'px)'}">
         <div class="content__header">
             <h2  class="heading-secondary">Display Area</h2>
         </div>

--- a/tools/ReFlex.TrackingServer/ClientApp/src/app/calibration/calibration.component.scss
+++ b/tools/ReFlex.TrackingServer/ClientApp/src/app/calibration/calibration.component.scss
@@ -92,7 +92,7 @@
     &__panel {
         position: absolute;
         top: 5rem;
-        left: -41rem;
+        left: 5rem;
         width: 36rem;
     
         padding: 1.5rem;

--- a/tools/ReFlex.TrackingServer/ClientApp/src/sass/components/_toggle.scss
+++ b/tools/ReFlex.TrackingServer/ClientApp/src/sass/components/_toggle.scss
@@ -120,6 +120,7 @@
     span.text {
       display: block;
       margin-top: 0.6rem;
+      font-family: $font-tertiary;
     }
     
   }


### PR DESCRIPTION
calibration panel is now aligned to the left to prevent visibility issues when viewport arewa is set to vbalues larger than display area
text ON/OFF toggles is now condensed to prevent overflow issues due to text length